### PR TITLE
correct the k_config_file_path to find the config file

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -16,7 +16,7 @@ char default_config_v1[]= "version=\n1\n\nkeywords=\nTODO:";
 #define default_config default_config_v1
 const int k_current_version= 1;
 
-const char *k_config_file_path="./plugins/config/npp_task_list.cfg";
+const char *k_config_file_path="./plugins/NppTaskList/config/npp_task_list.cfg";
 
 // globals
 


### PR DESCRIPTION
Seems like something changed in the past and was not adopted.
I've verified this issue by just creating a "hard link" from the existing config file in the new location to the location given here... with that change "TaskList" shows every key word and not onle the "default TODO:" again