### PR TITLE
Update TODO list only in case the list is changed

### DIFF
--- a/include/TaskListDlg.h
+++ b/include/TaskListDlg.h
@@ -50,7 +50,7 @@ public :
 	void setParent(HWND parent2set){
 		_hParent = parent2set;
 	};
-	std::string concatenateItems(const std::list<TodoItem>& itemList)
+	std::string itemsFingerprint(const std::list<TodoItem>& itemList)
 	{
 		// Create an empty string to store the concatenated content.
 		std::string concatenatedText;
@@ -63,11 +63,11 @@ public :
 		return concatenatedText;
 	}
 
-	std::string todoItemsStr;
+	std::string todoItemsFingerprint;
 
 	void SetList(const std::list<TodoItem>& items)
 	{
-		todoItemsStr = concatenateItems(items);
+		todoItemsFingerprint = itemsFingerprint(items);
 		
 		HWND _hList = ::GetDlgItem( _hSelf, ID_TODO_LIST );
 		if ( !_hList )
@@ -79,7 +79,7 @@ public :
 		// "if" branch replaces previous todoItems.clear(); to address the following issue:
 		// https://community.notepad-plus-plus.org/topic/23236/npp-task-list-plugin-window-overwrites/5
 			todoItems.clear();
-			todoItemsStr = "";
+			todoItemsFingerprint = "";
 			findTasks();
 			return;
 		}

--- a/include/TaskListDlg.h
+++ b/include/TaskListDlg.h
@@ -50,19 +50,36 @@ public :
 	void setParent(HWND parent2set){
 		_hParent = parent2set;
 	};
+	std::string concatenateItems(const std::list<TodoItem>& itemList)
+	{
+		// Create an empty string to store the concatenated content.
+		std::string concatenatedText;
+
+		// Iterate through the sorted list and concatenate the 'text' members.
+		for (const TodoItem& item : itemList) {
+			concatenatedText += item.text;
+		}
+
+		return concatenatedText;
+	}
+
+	std::string todoItemsStr;
 
 	void SetList(const std::list<TodoItem>& items)
 	{
+		todoItemsStr = concatenateItems(items);
+		
 		HWND _hList = ::GetDlgItem( _hSelf, ID_TODO_LIST );
 		if ( !_hList )
 			return;
 		//clear list LB_RESETCONTENT
 		::SendMessage( _hList, LB_RESETCONTENT, NULL, NULL );
-		if ( !todoItems.empty() )
+		if (!todoItems.empty())
 		{
 		// "if" branch replaces previous todoItems.clear(); to address the following issue:
 		// https://community.notepad-plus-plus.org/topic/23236/npp-task-list-plugin-window-overwrites/5
 			todoItems.clear();
+			todoItemsStr = "";
 			findTasks();
 			return;
 		}

--- a/include/TaskListDlg.h
+++ b/include/TaskListDlg.h
@@ -74,7 +74,7 @@ public :
 			return;
 		//clear list LB_RESETCONTENT
 		::SendMessage( _hList, LB_RESETCONTENT, NULL, NULL );
-		if (!todoItems.empty())
+		if ( !todoItems.empty() )
 		{
 		// "if" branch replaces previous todoItems.clear(); to address the following issue:
 		// https://community.notepad-plus-plus.org/topic/23236/npp-task-list-plugin-window-overwrites/5

--- a/src/PluginDefinition.cpp
+++ b/src/PluginDefinition.cpp
@@ -237,7 +237,7 @@ VOID CALLBACK MyTimerProc(
 		}
 	}
 	//display all todo's
-	if (_taskList.concatenateItems(todos) != _taskList.todoItemsStr) {
+	if (_taskList.itemsFingerprint(todos) != _taskList.todoItemsFingerprint) {
 		_taskList.SetList(todos);
 	}
 	

--- a/src/PluginDefinition.cpp
+++ b/src/PluginDefinition.cpp
@@ -236,9 +236,10 @@ VOID CALLBACK MyTimerProc(
 			search.chrg.cpMin = search.chrgText.cpMax + 1;
 		}
 	}
-
 	//display all todo's
-	_taskList.SetList(todos);
+	if (_taskList.concatenateItems(todos) != _taskList.todoItemsStr) {
+		_taskList.SetList(todos);
+	}
 	
 	//cleanup list
 	for (const auto &it : todos)


### PR DESCRIPTION
Only update the list if todo list changes.

**Problem statement:** TODO list is being updated on each keypress. That results in continous uncomfortable blinks of the list.

**Proposed solution:** keep fingerprint of current TODOs in TaskListDlg class (now in form of just concatenation of all TODOs, may be dangerous in case of huge number of TODOs, better to have it as MD5; but as even 1MB of TODOs, that is really a lot, will result in that very 1MB of additional memory, seems not that problematic) and update only in case TODOs changed.

**Nuance:** As I am not sure I completely understand concept behind **clearing and rescan** of TODOs in case todo list in dialog class is not empty (my initial intent would have been just to clear, but it seems it lead to some problems) - I just added "clear the fingerprint" (```todoItemsFingerprint = "";```) after the clear