### PR TITLE
Issue: 2.6.0 not available for automatic update in Notepad++, not satisfactory anyways

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # npp-task-list
 
-Fixed performance problems.
+Fixed performance problems
 
 ## Note :
 To compile this plugin you will need Visual Studio 2022.


### PR DESCRIPTION
Hey, I would have created an issue, but seems issues might be disabled or something.

Basically, I automatically updated the plugin today from version 2.4.0, but it updated only to version 2.5.0, so basically the horrible list refresh was introduced. I updated manually to 2.6.0, but I was sad to see the behaviour is only marginally better. In 2.4.0, only the changed task refreshes when a task is modified, meanwhile in 2.5.0 the whole list refreshes when anything changes. In 2.6.0 this is limited to the list refreshing when tasks are modified, but that still means the whole list flashes like crazy when task is being modified.

This is the behaviour on 2.4.0 (desirable):
![NPP TaskList 2 4 0](https://github.com/Megabyteceer/npp-task-list/assets/17746796/acd47b89-6c31-49bf-bbf2-c4fcf975326f)

And this is the behaviour on 2.6.0 (undesirable):
![TaskList 2 6 0](https://github.com/Megabyteceer/npp-task-list/assets/17746796/1321edd3-6a21-474b-b4d5-9a11860a2d39)
