### PR TITLE
Reverts NeArnold's change to TaskListDlg.h.SetList()

### DIFF
--- a/include/TaskListDlg.h
+++ b/include/TaskListDlg.h
@@ -74,15 +74,16 @@ public :
 			return;
 		//clear list LB_RESETCONTENT
 		::SendMessage( _hList, LB_RESETCONTENT, NULL, NULL );
-		if ( !todoItems.empty() )
-		{
-		// "if" branch replaces previous todoItems.clear(); to address the following issue:
-		// https://community.notepad-plus-plus.org/topic/23236/npp-task-list-plugin-window-overwrites/5
-			todoItems.clear();
-			todoItemsFingerprint = "";
-			findTasks();
-			return;
-		}
+		todoItems.clear();
+		//if ( !todoItems.empty() )
+		//{
+		//// "if" branch replaces previous todoItems.clear(); to address the following issue:
+		//// https://community.notepad-plus-plus.org/topic/23236/npp-task-list-plugin-window-overwrites/5
+		//	todoItems.clear();
+		//	todoItemsFingerprint = "";
+		//	findTasks();
+		//	return;
+		//}
 
 
 		//add list items LB_ADDSTRING


### PR DESCRIPTION
NeArnold's change causes any text in the Task list panel in Npp to flicker on redraw as the user types in the document AND I cannot recreate the issue he was trying to solve in the first place.